### PR TITLE
docs: add code execution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,28 @@ ollama pull {model choice}
    ```
    The application will open in your browser at [http://localhost:3000](http://localhost:3000).
 
+### Code Execution
+
+The backend can execute code inside sandboxed Docker containers.
+
+1. Build the execution image:
+   ```bash
+   cd backend/code_execution
+   docker build -t code-executor:latest .
+   ```
+2. Make sure Docker is running before starting the backend.
+3. Use the API to manage workspaces:
+   ```bash
+   curl -X POST http://127.0.0.1:8000/workspace/create      # create
+   curl http://127.0.0.1:8000/workspaces                    # list
+   curl -X DELETE http://127.0.0.1:8000/workspace/<id>      # delete
+   ```
+4. Run code within a workspace:
+   ```python
+   from code_execution.executor import execute_code
+   execute_code("print('hi')", "python", workspace_id)
+   ```
+
+See `backend/code_execution/readme.txt` for more examples.
+
 Happy chatting!

--- a/backend/code_execution/readme.txt
+++ b/backend/code_execution/readme.txt
@@ -1,8 +1,67 @@
-to use code_execution you will need to install the Docker App/Software
+# Code Execution
 
+This module allows the chat application to run small snippets of Python or
+JavaScript inside an isolated Docker container. Each session gets its own
+workspace so files created during execution are kept separate.
 
-run the following command  
-```docker build -t code-executor:latest .```
-in the code_execution directory (cd backend/code_execution)
+## Build the Docker image
 
-Docker MUST be running in the background for code_execution to function.
+1. Install and start Docker on your machine.
+2. From the `backend/code_execution` directory build the runtime image:
+
+   ```bash
+   docker build -t code-executor:latest .
+   ```
+
+## Workspace management
+
+Workspaces live under `backend/workspaces` and are created via the backend API.
+
+```bash
+# Create a workspace
+curl -X POST http://localhost:8000/workspace/create
+
+# List existing workspaces
+curl http://localhost:8000/workspaces
+
+# Delete a workspace
+curl -X DELETE http://localhost:8000/workspace/<workspace_id>
+```
+
+The create endpoint returns a JSON object with a `workspace_id` that is used for
+subsequent code and file operations.
+
+## Run code
+
+Code is executed inside the workspace with the helper function
+`execute_code`.
+
+```python
+from code_execution.executor import create_workspace, execute_code
+
+workspace_id, _ = create_workspace()
+result = execute_code("print('hello world')", "python", workspace_id)
+print(result["output"])
+```
+
+## Access files
+
+Files in the workspace can be accessed with `read_file` and `write_file`:
+
+```python
+from code_execution.executor import write_file, read_file
+
+write_file(workspace_id, "notes.txt", "some text")
+print(read_file(workspace_id, "notes.txt"))
+```
+
+## Sample UI flow
+
+1. The user starts a new chat session – the backend creates a workspace.
+2. When the model needs to run code, the backend calls `execute_code` inside
+   that workspace and returns the output.
+3. Generated files can be viewed by requesting them with `read_file` or by
+   listing the workspace contents.
+
+Docker must remain running in the background for code execution to work.
+


### PR DESCRIPTION
## Summary
- expand `backend/code_execution/readme.txt` with usage instructions and sample API calls
- document code execution workflow in main `README.md`

## Testing
- `pytest` *(fails: ProxyError: HTTPSConnectionPool(host='hugging...))*


------
https://chatgpt.com/codex/tasks/task_e_68bdf67c376c83218d2e20a6e50ec242