### PR TITLE
Add code execution API router

### DIFF
--- a/backend/api/code_execution.py
+++ b/backend/api/code_execution.py
@@ -1,0 +1,32 @@
+# backend/api/code_execution.py
+from fastapi import APIRouter
+from pydantic import BaseModel
+from code_execution import executor
+
+router = APIRouter()
+
+
+class CodeExecutionRequest(BaseModel):
+    code: str
+    language: str
+
+
+class FileContentRequest(BaseModel):
+    content: str
+
+
+@router.post("/workspace/{workspace_id}/execute")
+async def execute_code_endpoint(workspace_id: str, request: CodeExecutionRequest):
+    return executor.execute_code(request.code, request.language, workspace_id)
+
+
+@router.get("/workspace/{workspace_id}/file/{filename}")
+async def read_file_endpoint(workspace_id: str, filename: str):
+    content = executor.read_file(workspace_id, filename)
+    return {"content": content}
+
+
+@router.post("/workspace/{workspace_id}/file/{filename}")
+async def write_file_endpoint(workspace_id: str, filename: str, request: FileContentRequest):
+    executor.write_file(workspace_id, filename, request.content)
+    return {"message": "File written successfully"}

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,7 +7,17 @@ import os
 
 from database import engine
 import models
-from api import chat, session, models_list, chat_history, metrics, web_search, upload, custom_inference
+from api import (
+    chat,
+    session,
+    models_list,
+    chat_history,
+    metrics,
+    web_search,
+    upload,
+    custom_inference,
+    code_execution,
+)
 from code_execution import executor
 from config import load_system_prompts
 from ollama_integration import call_ollama_api  # Updated import
@@ -55,6 +65,7 @@ app.include_router(chat_history.router)
 app.include_router(metrics.router)
 app.include_router(web_search.router)
 app.include_router(upload.router)
+app.include_router(code_execution.router)
 
 # --- Workspace Management Endpoints ---
 @app.post("/workspace/create")


### PR DESCRIPTION
## Summary
- expose code execution, file read, and file write endpoints via new API router
- register the code execution router with the FastAPI app

## Testing
- `pytest` *(fails: ProxyError: unable to connect to huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf678b39883218fbbdefbe923768f