### PR TITLE
feat: add live browsing pipeline and multimodal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a complete chat interface application. The app lets use
 
 ## Features
 - **Local Search:** The model can search local documents to answer questions.
+- **Live Browsing:** When `use_browser` is enabled, the backend fetches current news from RSS feeds, site search or topic hubs and returns a summary with citations. Sources are saved under `backend/local_data/web_live` for hybrid search.
+- **Multimodal Ingestion:** Images, audio and video can be analyzed and transcribed. Extracted text is written to `backend/local_data/mm` so text-only models can reference it.
 - Send messages to language models.
 - Select a model for each conversation.
 - Store chat messages (user and model responses) in an SQLite database.
@@ -105,6 +107,13 @@ ollama pull {model choice}
    uvicorn app:app --reload
    ```
    The backend server will run at [http://127.0.0.1:8000](http://127.0.0.1:8000).
+   A root health check is available at `/` and `/healthz`.
+
+### Live Browsing
+The live browsing tools read their configuration from `backend/config/sources.yaml` (optional). If the file is absent the defaults in code are used. To enable browsing in the chat UI, toggle the **Use Browser** option. Retrieved documents are stored in `backend/local_data/web_live` and reindexed for search.
+
+### Multimodal
+Optional models and settings are configured in `backend/config/mm.yaml`. Endpoints under `/tools/mm/*` handle image captioning/OCR, audio transcription, video keyframes and ingestion. The backend will continue to run even if these models fail to load.
 
 ### Frontend
 1. Navigate to the `frontend` folder:

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -29,6 +29,7 @@ from tools.live_browse import (
     SiteSearchResponse,
     FetchResponseItem,
 )
+from tools.live_browse_utils import compute_reliability, pick_hubs
 from tools.multimodal import (
     image_analyze,
     audio_transcribe,
@@ -100,48 +101,51 @@ async def _extract_links_from_html(html_content: str, base_url: str) -> List[str
                 pass
     return list(links)
 
-async def homepage_fallback_strategy(query: str):
-    logger.info("Executing homepage fallback strategy")
+async def browse_first_pipeline(query: str):
     config = get_config()
+    policy = config.get("ingest_policy", {})
+    path_used = "rss"
+    try:
+        rss_resp = await rss_latest(RssRequest(max_items=5))
+        urls = [i.url for i in rss_resp.items]
+    except Exception:
+        urls = []
 
-    ai_keywords = ['ai', 'artificial intelligence', 'ml', 'machine learning']
-    is_ai_query = any(keyword in query.lower() for keyword in ai_keywords)
+    if not urls:
+        path_used = "site_search"
+        try:
+            ss_resp = await site_search(SiteSearchRequest(query=query, max_items=5))
+            urls = [i.url for i in ss_resp.items]
+        except Exception:
+            urls = []
 
-    if is_ai_query:
-        hubs = [
-            "https://www.nature.com/subjects/artificial-intelligence",
-            "https://ai.googleblog.com/",
-            "https://openai.com/blog",
-            "https://www.deepmind.com/blog",
-            "https://venturebeat.com/category/ai/",
-        ]
-        logger.info("Using AI-focused hubs for fallback.")
-    else:
-        hubs = [
-            "https://www.reuters.com/",
-            "https://www.theverge.com/",
-            "https://www.npr.org/sections/news/",
-            "https://news.ycombinator.com/",
-        ]
-        logger.info("Using general news hubs for fallback.")
+    if not urls:
+        path_used = "homepage_fallback"
+        urls = pick_hubs(query, config)[:5]
 
-    fetched_pages = await fetch(FetchRequest(urls=hubs[:5]))
+    fetched = []
+    if urls:
+        fetched = await fetch(FetchRequest(urls=urls))
 
-    all_links = []
-    for page in fetched_pages:
-        links = await _extract_links_from_html(page.text, page.url)
-        all_links.extend(links)
+    accepted = []
+    for item in fetched:
+        d = item.dict()
+        score = compute_reliability(d, policy)
+        if score >= policy.get("min_reliability", 0):
+            d["score"] = score
+            accepted.append(d)
 
-    if not all_links:
-        logger.warning("No links found in fallback hubs.")
-        return
+    if accepted:
+        ingest_items = [{"url": d["url"], "title": d.get("title", ""), "text": d["text"]} for d in accepted]
+        await ingest(IngestRequest(items=ingest_items))
 
-    fetched_articles = await fetch(FetchRequest(urls=list(set(all_links))[:20]))
-
-    if fetched_articles:
-        ingest_req = IngestRequest(items=[item.dict() for item in fetched_articles])
-        await ingest(ingest_req)
-        logger.info(f"Fallback ingested {len(fetched_articles)} documents.")
+    summary_lines = []
+    sources = []
+    for i, d in enumerate(accepted, 1):
+        summary_lines.append(f"{i}. {d['title']} ({d['url']})")
+        sources.append({"url": d['url'], "title": d['title']})
+    summary = "\n".join(summary_lines) if summary_lines else "No live results found."
+    return summary, sources, path_used
 
 
 @router.post("/chat", response_model=schemas.ChatResponse)
@@ -210,8 +214,18 @@ async def send_chat_message(
         code_execution_tool = create_code_execution_tool(current_workspace_id)
 
         if use_browser:
-            logger.info("Attempting live browse...")
-            # (Browser logic remains the same)
+            summary, sources, path_used = await browse_first_pipeline(user_message)
+            logger.info(f"browse_path={path_used}")
+            model_reply = summary
+            crud.create_message(db, session_obj.id, sender="model", content=model_reply)
+            reasoning_steps.append({"tool": f"browse_{path_used}", "tool_input": {"query": user_message}, "observation": {"sources": sources}})
+            return schemas.ChatResponse(
+                session_id=session_obj.id,
+                user_message=user_message,
+                model_message=model_reply,
+                model_id=model_id,
+                reasoning=reasoning_steps,
+            )
 
         system_prompt_key = persona or "default"
         system_prompt = system_prompts.get(system_prompt_key, system_prompts["default"])["prompt"]

--- a/backend/config/mm.yaml
+++ b/backend/config/mm.yaml
@@ -1,5 +1,5 @@
 image:
-  caption_model: "blip-base"     # or "blip-large"
+  caption_model: "base"     # or "large"
   ocr: "paddleocr"               # or "tesseract"
   detect_objects: false          # toggle YOLOv8n
 audio:

--- a/backend/config/sources.yaml
+++ b/backend/config/sources.yaml
@@ -51,3 +51,10 @@
 #   allowlist_domains": []
 #   max_per_domain: 30
 #   dedupe_by": ["canonical_url", "sha1_text"]
+# topic_hubs:
+#   general:
+#     - "https://www.reuters.com/"
+#     - "https://www.bbc.com/news"
+#   ai:
+#     - "https://www.nature.com/subjects/artificial-intelligence"
+#     - "https://openai.com/blog"

--- a/backend/tests/test_reliability_and_fts.py
+++ b/backend/tests/test_reliability_and_fts.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+import sys, pathlib
+base = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(base))
+from tools.termsearch.core import _fts_safe
+from tools.live_browse_utils import compute_reliability
+
+def test_fts_safe_apostrophe():
+    assert _fts_safe("today's news") == '"today\'s" "news"'
+
+def test_compute_reliability_trusted():
+    doc = {
+        "url": "https://www.reuters.com/some-article",
+        "text": "a" * 1200 + " http http http",
+        "meta": {"fetched_at": datetime.utcnow().isoformat(), "author": "Anon"},
+    }
+    policy = {"freshness_days": 7}
+    score = compute_reliability(doc, policy)
+    assert score >= 0.55

--- a/backend/tools/live_browse.py
+++ b/backend/tools/live_browse.py
@@ -49,6 +49,7 @@ class FetchResponseItem(BaseModel):
     url: str
     title: str
     text: str
+    meta: Dict[str, Any] = {}
 
 class IngestRequest(BaseModel):
     items: List[Dict[str, Any]]
@@ -92,6 +93,24 @@ DEFAULT_CONFIG = {
     "allowlist_domains": [],
     "max_per_domain": 30,
     "dedupe_by": ["canonical_url","sha1_text"]
+  },
+  "topic_hubs": {
+    "general": [
+      "https://www.reuters.com/",
+      "https://www.bbc.com/news",
+      "https://www.npr.org/sections/news/",
+      "https://arstechnica.com/",
+      "https://www.theverge.com/",
+      "https://news.ycombinator.com/"
+    ],
+    "ai": [
+      "https://www.nature.com/subjects/artificial-intelligence",
+      "https://ai.googleblog.com/",
+      "https://openai.com/blog",
+      "https://www.deepmind.com/blog",
+      "https://venturebeat.com/category/ai/",
+      "https://techcrunch.com/tag/ai/"
+    ]
   }
 }
 
@@ -196,6 +215,7 @@ async def fetch(request: FetchRequest):
     """
     async def fetch_one(url: str):
         try:
+            await asyncio.sleep(0.5)
             async with httpx.AsyncClient() as client:
                 response = await client.get(url, follow_redirects=True, timeout=15)
                 response.raise_for_status()
@@ -208,7 +228,8 @@ async def fetch(request: FetchRequest):
             if not text:
                 return None
 
-            return FetchResponseItem(url=url, title=title, text=text)
+            meta = {"fetched_at": datetime.utcnow().isoformat(), "length": len(text)}
+            return FetchResponseItem(url=url, title=title, text=text, meta=meta)
         except httpx.RequestError as e:
             logger.warning(f"Error fetching URL {url}: {e}")
             return None
@@ -232,23 +253,49 @@ async def ingest(request: IngestRequest):
     indexed_files = []
     for item in request.items:
         try:
-            url_hash = hashlib.sha256(item['url'].encode()).hexdigest()
-            # Ensure subdirectory exists, e.g., web_live/ab/cd/abcdef...
-            subdir = data_dir / url_hash[:2] / url_hash[2:4]
-            subdir.mkdir(parents=True, exist_ok=True)
+            url = item['url']
+            text = item['text']
+            title = item.get('title', '')
+            canonical_url = item.get('canonical_url', url)
+            sha1_text = hashlib.sha1(text.encode('utf-8')).hexdigest()
+            sha16 = sha1_text[:16]
+            domain = httpx.URL(canonical_url).host or "unknown"
+            domain_dir = data_dir / domain
+            domain_dir.mkdir(parents=True, exist_ok=True)
 
-            filepath = subdir / f"{url_hash}.md"
+            # dedupe by canonical_url or sha1_text
+            existing_canon = set()
+            existing_sha = set()
+            for fp in domain_dir.glob("*.md"):
+                try:
+                    with fp.open('r', encoding='utf-8') as f:
+                        if f.readline().strip() != '---':
+                            continue
+                        meta_lines = []
+                        for line in f:
+                            if line.strip() == '---':
+                                break
+                            meta_lines.append(line)
+                    meta = yaml.safe_load(''.join(meta_lines)) or {}
+                    existing_canon.add(meta.get('canonical_url'))
+                    existing_sha.add(meta.get('sha1_text'))
+                except Exception:
+                    continue
+            if canonical_url in existing_canon or sha1_text in existing_sha:
+                continue
 
+            filepath = domain_dir / f"{sha16}.md"
             ingested_at = datetime.utcnow().isoformat()
             front_matter = {
                 "source": "web_live",
-                "url": item['url'],
-                "title": item['title'],
+                "url": url,
+                "canonical_url": canonical_url,
+                "title": title,
+                "sha1_text": sha1_text,
                 "ingested_at": ingested_at,
             }
-            content = f"---\n{yaml.dump(front_matter)}---\n\n{item['text']}"
-
-            with open(filepath, "w", encoding="utf-8") as f:
+            content = f"---\n{yaml.dump(front_matter)}---\n\n{text}"
+            with open(filepath, 'w', encoding='utf-8') as f:
                 f.write(content)
             indexed_files.append(str(filepath))
         except Exception as e:

--- a/backend/tools/live_browse_utils.py
+++ b/backend/tools/live_browse_utils.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+import math
+from datetime import datetime, timedelta
+from typing import Dict, Any, List
+from urllib.parse import urlparse
+
+TRUSTED_DOMAINS = {
+    "reuters.com",
+    "bbc.co.uk",
+    "bbc.com",
+    "npr.org",
+    "arstechnica.com",
+    "theverge.com",
+    "nature.com",
+    "ai.googleblog.com",
+    "openai.com",
+    "deepmind.com",
+    "venturebeat.com",
+    "techcrunch.com",
+}
+
+def compute_reliability(doc: Dict[str, Any], policy: Dict[str, Any]) -> float:
+    """Compute a crude reliability score in [0,1]."""
+    score = 0.0
+    url = doc.get("url", "")
+    text = doc.get("text", "")
+    meta = doc.get("meta", {})
+    domain = urlparse(url).netloc.lower()
+
+    if domain in TRUSTED_DOMAINS:
+        score += 0.3
+    if url.startswith("https://"):
+        score += 0.1
+    if len(text) > 1000:
+        score += 0.2
+    fetched_at = meta.get("fetched_at")
+    if fetched_at:
+        try:
+            ts = datetime.fromisoformat(fetched_at)
+            if datetime.utcnow() - ts < timedelta(days=policy.get("freshness_days", 7)):
+                score += 0.2
+        except Exception:
+            pass
+    if meta.get("author"):
+        score += 0.1
+    if text.count("http") >= 3:
+        score += 0.1
+    return min(score, 1.0)
+
+AI_KEYWORDS = {"ai", "artificial intelligence", "ml", "machine learning", "gpt", "llm", "transformer"}
+
+def pick_hubs(query: str, config: Dict[str, Any]) -> List[str]:
+    hubs_cfg = config.get("topic_hubs", {})
+    is_ai = any(k in query.lower() for k in AI_KEYWORDS)
+    return hubs_cfg.get("ai" if is_ai else "general", [])
+

--- a/backend/tools/multimodal.py
+++ b/backend/tools/multimodal.py
@@ -73,7 +73,7 @@ asr_model = None
 
 # Load BLIP model
 try:
-    model_name = IMAGE_CONFIG.get("caption_model", "blip-base")
+    model_name = IMAGE_CONFIG.get("caption_model", "base")
     model_path = f"Salesforce/blip-image-captioning-{model_name}"
     blip_processor = BlipProcessor.from_pretrained(model_path)
     blip_model = BlipForConditionalGeneration.from_pretrained(model_path)
@@ -86,7 +86,7 @@ except Exception as e:
 # Load OCR model
 if IMAGE_CONFIG.get("ocr") == "paddleocr":
     try:
-        ocr_reader = paddleocr.PaddleOCR(use_angle_cls=True, lang='en', show_log=False)
+        ocr_reader = paddleocr.PaddleOCR(use_angle_cls=True, lang='en')
         print("PaddleOCR model loaded successfully.")
     except Exception as e:
         ocr_reader = None

--- a/frontend/src/components/ReasoningView.js
+++ b/frontend/src/components/ReasoningView.js
@@ -101,10 +101,21 @@ const ReasoningView = ({ reasoning }) => {
           const isVideo = step.tool === 'multimodal_video_analyzer';
           const isImage = step.tool === 'multimodal_image_analyzer';
           const isAudio = step.tool === 'multimodal_audio_analyzer';
+          const isBrowse = step.tool && step.tool.startsWith('browse_');
           const isMultimodal = isVideo || isImage || isAudio;
 
           let observationContent;
-          if (typeof step.observation !== 'object' || step.observation === null) {
+          if (isBrowse && step.observation && Array.isArray(step.observation.sources)) {
+            observationContent = (
+              <List dense>
+                {step.observation.sources.map((s, i) => (
+                  <ListItem key={i} component="a" href={s.url} target="_blank">
+                    <ListItemText primary={s.title} secondary={s.url} />
+                  </ListItem>
+                ))}
+              </List>
+            );
+          } else if (typeof step.observation !== 'object' || step.observation === null) {
             observationContent = <CodeBlock language="text" value={String(step.observation)} />;
           } else if (isVideo) {
             observationContent = <VideoAnalysisViewer observation={step.observation} />;


### PR DESCRIPTION
## Summary
- add deterministic browse-first pipeline with reliability scoring and ingestion
- include optional multimodal tooling and front-end sources panel
- document live browsing and multimodal configuration

## Testing
- `pytest backend/tests/test_reliability_and_fts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c70c5b7e14832198c834129944b40f