### PR TITLE
Refine live browse dedupe and video analysis fallback

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -201,7 +201,7 @@ async def send_chat_message(
                 elif modality == "video":
                     analysis_result = await video_analyze(file)
                     analysis_summary = f"Video Analysis:\nSummary: {analysis_result.summary}\nTranscript: {analysis_result.transcript}"
-                    fragments = analysis_result.frames
+                    fragments = analysis_result.scenes
                     if analysis_result.transcript: fragments.append({"type": "transcript", "text": analysis_result.transcript})
                     payload = IngestPayload(modality="video", metadata={"original_file": file.filename}, text=analysis_summary, fragments=fragments)
                     await mm_ingest(payload)

--- a/backend/system_prompts/code_tester.json
+++ b/backend/system_prompts/code_tester.json
@@ -1,6 +1,6 @@
 {
     "code_tester": {
       "description": "An assistant focused on testing and validating code.",
-      "prompt": "You are a code testing assistant. Your primary goal is to help users test and validate their code. You have a workspace where you can execute code, write files (for test cases or data), and read files. Use these capabilities extensively to run tests and report results.\n\nTo execute:\n```execute <language>\n[code]```\n\nTo write:\n```file_write <filename>\n[content]```\n\nTo read:\n```file_read <filename>```\n\nPrioritize testing and provide detailed results."
+      "prompt": "You are a code testing assistant. Your primary goal is to help users test and validate their code. You have a workspace where you can execute code to run tests and report results.\n\nTo execute:\n```execute <language>\n[code]```\n\nPrioritize testing and provide detailed results."
     }
   }

--- a/backend/system_prompts/gen_coding_assistant.json
+++ b/backend/system_prompts/gen_coding_assistant.json
@@ -1,6 +1,6 @@
 {
   "default": {
     "description": "A general-purpose coding assistant.",
-    "prompt": "You are a helpful coding assistant. You can execute code, write files, and read files within a persistent workspace.\n\nTo execute code, use the following format:\n```execute <language>\n[code]```\n\nTo write to a file:\n```file_write <filename>\n[file content]```\n\nTo read from a file:\n```file_read <filename>```\n\nThe output of your commands will be shown in the chat.  After writing code, *always* execute it to verify its correctness and show the output to the user. If the user asks you to create or modify a file, always read the file back after writing to confirm the changes."
+    "prompt": "You are a helpful coding assistant. You can execute code within a persistent workspace.\n\nTo execute code, use the following format:\n```execute <language>\n[code]```\n\nThe output of your commands will be shown in the chat. After writing code, *always* execute it to verify its correctness and show the output to the user."
   }
 }

--- a/backend/system_prompts/javascript_expert.json
+++ b/backend/system_prompts/javascript_expert.json
@@ -1,6 +1,6 @@
 {
    "javascript_expert": {
         "description": "Assistance in Javascript.",
-        "prompt": "You are an expert Javascript programmer. You have a persistent workspace where you can execute Python code, write files, and read files.  Use these capabilities to help users solve Javascript-related problems.\n\nTo execute code:\n```execute javascript\n[code]```\n\nTo write:\n```file_write <filename>\n[content]```\n\nTo read:\n```file_read <filename>```\n\nResults will be displayed in the chat. Focus on providing helpful Python code and explanations."
+        "prompt": "You are an expert Javascript programmer. You have a persistent workspace where you can execute code to help users solve Javascript-related problems.\n\nTo execute code:\n```execute javascript\n[code]```\n\nResults will be displayed in the chat. Focus on providing helpful code and explanations."
     }
   }

--- a/backend/system_prompts/python_expert.json
+++ b/backend/system_prompts/python_expert.json
@@ -1,6 +1,6 @@
 {
   "python_expert": {
     "description": "An assistant specialized in Python programming.",
-    "prompt": "You are an expert Python programmer. You have a persistent workspace where you can execute Python code, write files, and read files.  Use these capabilities to help users solve Python-related problems.\n\nTo execute code:\n```execute python\n[code]```\n\nTo write:\n```file_write <filename>\n[content]```\n\nTo read:\n```file_read <filename>```\n\nResults will be displayed in the chat. Focus on providing helpful Python code and explanations. After writing Python code, *always* execute it using the `execute` command to show the output to the user."
+    "prompt": "You are an expert Python programmer. You have a persistent workspace where you can execute Python code to help users solve Python-related problems.\n\nTo execute code:\n```execute python\n[code]```\n\nResults will be displayed in the chat. Focus on providing helpful Python code and explanations. After writing Python code, *always* execute it using the `execute` command to show the output to the user."
   }
 }

--- a/backend/tools/live_browse.py
+++ b/backend/tools/live_browse.py
@@ -13,6 +13,7 @@ import hashlib
 from .search_engine import SearchEngine
 from pathlib import Path
 import logging
+from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,20 @@ def get_config():
     import logging
     logging.getLogger(__name__).warning("sources.yaml not found; using DEFAULT_CONFIG")
     return DEFAULT_CONFIG
+
+
+def canonicalize_url(url: str) -> str:
+    """Normalize URL for deduplication."""
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        netloc = parsed.netloc.lower()
+        path = parsed.path.lower()
+        if path.endswith('/') and path != '/':
+            path = path[:-1]
+        return urlunparse((scheme, netloc, path, '', '', ''))
+    except Exception:
+        return url
 
 # --- Endpoints ---
 
@@ -256,10 +271,10 @@ async def ingest(request: IngestRequest):
             url = item['url']
             text = item['text']
             title = item.get('title', '')
-            canonical_url = item.get('canonical_url', url)
+            canonical_url = canonicalize_url(item.get('canonical_url', url))
             sha1_text = hashlib.sha1(text.encode('utf-8')).hexdigest()
-            sha16 = sha1_text[:16]
-            domain = httpx.URL(canonical_url).host or "unknown"
+            url_hash = hashlib.sha1(canonical_url.encode('utf-8')).hexdigest()[:16]
+            domain = urlparse(canonical_url).netloc or "unknown"
             domain_dir = data_dir / domain
             domain_dir.mkdir(parents=True, exist_ok=True)
 
@@ -277,14 +292,14 @@ async def ingest(request: IngestRequest):
                                 break
                             meta_lines.append(line)
                     meta = yaml.safe_load(''.join(meta_lines)) or {}
-                    existing_canon.add(meta.get('canonical_url'))
+                    existing_canon.add(canonicalize_url(meta.get('canonical_url', '')))
                     existing_sha.add(meta.get('sha1_text'))
                 except Exception:
                     continue
             if canonical_url in existing_canon or sha1_text in existing_sha:
                 continue
 
-            filepath = domain_dir / f"{sha16}.md"
+            filepath = domain_dir / f"{url_hash}.md"
             ingested_at = datetime.utcnow().isoformat()
             front_matter = {
                 "source": "web_live",

--- a/backend/tools/multimodal.py
+++ b/backend/tools/multimodal.py
@@ -30,7 +30,7 @@ class AudioTranscriptionResponse(BaseModel):
 
 class VideoAnalysisResponse(BaseModel):
     summary: str
-    frames: List[Dict[str, Any]]
+    scenes: List[Dict[str, Any]]
     transcript: str
     artifact_path: str
 
@@ -204,7 +204,7 @@ async def video_analyze(file: UploadFile = File(...)):
     video_path_str = str(p)
 
     transcript = ""
-    frames_data = []
+    scenes_data = []
     summary = ""
 
     video_artifacts_dir = p.parent / p.stem
@@ -253,17 +253,19 @@ async def video_analyze(file: UploadFile = File(...)):
                         result = ocr_reader.ocr(img_path, cls=True)
                         if result and result[0] is not None:
                             frame_info["ocr"] = "\n".join([line[1][0] for line in result[0]])
-                    frames_data.append(frame_info)
+                    scenes_data.append(frame_info)
         except Exception:
             pass
 
-        summary = " ".join([f["caption"] for f in frames_data if f["caption"]])
+        summary = " ".join([f["caption"] for f in scenes_data if f["caption"]])
 
     except Exception as e:
         summary = f"A fatal error occurred during video analysis: {e}"
 
     return VideoAnalysisResponse(
-        summary=summary, frames=frames_data, transcript=transcript,
+        summary=summary if summary else "No keyframes detected; only base metadata extracted.",
+        scenes=scenes_data,
+        transcript=transcript,
         artifact_path=str(p.relative_to(MM_DIR))
     )
 

--- a/frontend/src/components/ReasoningView.js
+++ b/frontend/src/components/ReasoningView.js
@@ -24,11 +24,11 @@ const VideoAnalysisViewer = ({ observation }) => {
                     </Typography>
                 </>
             )}
-            {observation.frames && observation.frames.length > 0 && (
+            {observation.scenes && observation.scenes.length > 0 && (
                 <>
                     <Typography variant="body2" sx={{ fontWeight: 'bold' }}>Keyframes:</Typography>
                     <ImageList cols={3} rowHeight={164}>
-                        {observation.frames.map((frame, index) => {
+                        {observation.scenes.map((frame, index) => {
                             const imageUrl = `${API_URL}/tools/mm/artifacts/${frame.path}`;
                             return (
                                 <ImageListItem key={index}>


### PR DESCRIPTION
## Summary
- strip unused file_read/file_write commands from all system prompts
- return safe fallback when video analysis has no keyframes and expose scenes list
- normalize URLs for live browsing ingest to dedupe repeated results

## Testing
- `pytest -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c75330d6ac83219137ec9386c4f72a