### PR TITLE
feat: make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ Optional models and settings are configured in `backend/config/mm.yaml`. Endpoin
    ```
    The application will open in your browser at [http://localhost:3000](http://localhost:3000).
 
+#### Backend API URL
+
+The frontend reads the backend base URL from the `REACT_APP_API_URL` environment variable. During development it defaults to `http://127.0.0.1:8000`.
+You can override this by creating a `.env` file in the `frontend` directory or by setting the variable at build time:
+
+```bash
+REACT_APP_API_URL=https://your-backend.example.com npm start
+```
+
 ### Code Execution
 
 The backend can execute code inside sandboxed Docker containers.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,6 @@
     // frontend/src/api.js
     import axios from 'axios';
-
-    const API_URL = 'http://127.0.0.1:8000'; //backend url
+    import { API_URL } from './config';
 
     export const createSession = async () => {
       const response = await axios.post(`${API_URL}/session`);

--- a/frontend/src/components/FileUpload.js
+++ b/frontend/src/components/FileUpload.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Box, Button, Typography } from '@mui/material';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import axios from 'axios';
+import { API_URL } from '../config';
 
 const FileUpload = ({ onAddMessage }) => {
   const [file, setFile] = useState(null);
@@ -18,7 +19,7 @@ const FileUpload = ({ onAddMessage }) => {
     formData.append('file', file);
 
     try {
-      const response = await axios.post("http://127.0.0.1:8000/upload", formData, {
+      const response = await axios.post(`${API_URL}/upload`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' }
       });
       setUploadResult(response.data);

--- a/frontend/src/components/HardwareMetrics.js
+++ b/frontend/src/components/HardwareMetrics.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Typography, Grid, Paper } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import axios from 'axios';
+import { API_URL } from '../config';
 
 const HardwareMetrics = () => {
   const [metrics, setMetrics] = useState(null);
@@ -10,7 +11,7 @@ const HardwareMetrics = () => {
 
   const fetchMetrics = async () => {
     try {
-      const response = await axios.get('http://127.0.0.1:8000/metrics');
+      const response = await axios.get(`${API_URL}/metrics`);
       setMetrics(response.data);
       setLoading(false);
     } catch (error) {

--- a/frontend/src/components/ReasoningView.js
+++ b/frontend/src/components/ReasoningView.js
@@ -3,8 +3,7 @@ import React from 'react';
 import { Box, Typography, Accordion, AccordionSummary, AccordionDetails, ImageList, ImageListItem, ImageListItemBar, List, ListItem, ListItemText } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CodeBlock from './CodeBlock';
-
-const API_URL = 'http://127.0.0.1:8000';
+import { API_URL } from '../config';
 
 const VideoAnalysisViewer = ({ observation }) => {
     if (!observation) return null;

--- a/frontend/src/components/WebSearch.js
+++ b/frontend/src/components/WebSearch.js
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { Box, TextField, Button, Typography, List, ListItem, Divider } from '@mui/material';
 import axios from 'axios';
+import { API_URL } from '../config';
 
 const WebSearch = ({ onAddMessage }) => {
   const [query, setQuery] = useState("");
@@ -11,7 +12,7 @@ const WebSearch = ({ onAddMessage }) => {
     if (!query.trim()) return;
     setLoading(true);
     try {
-      const response = await axios.get("http://127.0.0.1:8000/search", { params: { query } });
+      const response = await axios.get(`${API_URL}/search`, { params: { query } });
       const data = response.data;
       // Build a message that summarizes the search result.
       const searchMessage = `**Web Search Result for "${query}":**\n\nAbstract: ${data.abstract || "No abstract available."}\n\n` +

--- a/frontend/src/components/WorkspaceManager.js
+++ b/frontend/src/components/WorkspaceManager.js
@@ -2,8 +2,9 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Typography, List, ListItem, ListItemText, Button, TextField } from '@mui/material';
 import { createWorkspace, deleteWorkspace } from '../api';
-import {ListSubheader} from '@mui/material';
+import { ListSubheader } from '@mui/material';
 import axios from 'axios'; // Import axios
+import { API_URL } from '../config';
 
 const WorkspaceManager = () => {
   const [workspaces, setWorkspaces] = useState([]);
@@ -13,7 +14,7 @@ const WorkspaceManager = () => {
     // Fetch workspaces from the backend
     const fetchWorkspaces = async () => {
         try{
-            const response = await axios.get('http://127.0.0.1:8000/workspaces');
+            const response = await axios.get(`${API_URL}/workspaces`);
             setWorkspaces(response.data.workspaces);
         } catch (error) {
             console.error("Error fetching workspaces:", error);

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,8 @@
+// frontend/src/config.js
+// Central configuration for frontend runtime variables.
+
+// The backend API base URL can be provided via the
+// environment variable REACT_APP_API_URL. During development
+// it defaults to the local FastAPI server.
+export const API_URL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:8000';
+


### PR DESCRIPTION
## Summary
- read backend URL from `REACT_APP_API_URL` with local default
- replace hard-coded API URLs across frontend components
- document `REACT_APP_API_URL` in README

## Testing
- `CI=true npm test --prefix frontend -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c759b2d46883219b47b20ffcb0007d