### PR TITLE
Add Scene model for video analysis

### DIFF
--- a/backend/tests/test_multimodal_models.py
+++ b/backend/tests/test_multimodal_models.py
@@ -1,0 +1,70 @@
+import unittest
+from pydantic import ValidationError
+import os, sys, types
+
+# Stub heavy dependencies before importing multimodal module
+sys.modules['torch'] = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+
+class _DummyModel:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+    def __call__(self, *args, **kwargs):
+        return {}
+    def generate(self, *args, **kwargs):
+        return [[0]]
+    def decode(self, *args, **kwargs):
+        return ""
+
+sys.modules['transformers'] = types.SimpleNamespace(
+    BlipProcessor=_DummyModel,
+    BlipForConditionalGeneration=_DummyModel,
+)
+sys.modules['paddleocr'] = types.SimpleNamespace(PaddleOCR=lambda *a, **k: None)
+class _DummyWhisper:
+    def __init__(self, *a, **k):
+        pass
+    def transcribe(self, *a, **k):
+        return [], None
+sys.modules['faster_whisper'] = types.SimpleNamespace(WhisperModel=_DummyWhisper)
+
+scenedetect_module = types.SimpleNamespace(
+    open_video=lambda *a, **k: None,
+    SceneManager=lambda *a, **k: types.SimpleNamespace(
+        add_detector=lambda *a, **k: None,
+        detect_scenes=lambda *a, **k: None,
+        get_scene_list=lambda: []
+    ),
+)
+sys.modules['scenedetect'] = scenedetect_module
+sys.modules['scenedetect.detectors'] = types.SimpleNamespace(ContentDetector=lambda *a, **k: None)
+sys.modules['scenedetect.scene_manager'] = types.SimpleNamespace(save_images=lambda *a, **k: {})
+sys.modules['tools.search_engine'] = types.SimpleNamespace(SearchEngine=lambda *a, **k: None)
+
+# Add the backend directory to the sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tools.multimodal import Scene, VideoAnalysisResponse
+
+class TestSceneModel(unittest.TestCase):
+    def test_scene_requires_t_and_path(self):
+        with self.assertRaises(ValidationError):
+            Scene(path='frame.jpg')
+        with self.assertRaises(ValidationError):
+            Scene(t=1.0)
+        scene = Scene(t=1.0, path='frame.jpg')
+        self.assertEqual(scene.t, 1.0)
+        self.assertEqual(scene.path, 'frame.jpg')
+        self.assertIsNone(scene.caption)
+        self.assertIsNone(scene.ocr)
+
+    def test_video_analysis_response_validates_scenes(self):
+        invalid_scene = {'t': 1.0}
+        with self.assertRaises(ValidationError):
+            VideoAnalysisResponse(summary='s', scenes=[invalid_scene], transcript='t', artifact_path='p')
+        scenes = [Scene(t=0.0, path='f.jpg')]
+        resp = VideoAnalysisResponse(summary='s', scenes=scenes, transcript='t', artifact_path='p')
+        self.assertEqual(resp.scenes[0].path, 'f.jpg')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tools/multimodal.py
+++ b/backend/tools/multimodal.py
@@ -28,9 +28,15 @@ class AudioTranscriptionResponse(BaseModel):
     segments: List[Dict[str, Any]]
     artifact_path: str
 
+class Scene(BaseModel):
+    t: float
+    path: str
+    caption: str | None = None
+    ocr: str | None = None
+
 class VideoAnalysisResponse(BaseModel):
     summary: str
-    scenes: List[Dict[str, Any]]
+    scenes: List[Scene]
     transcript: str
     artifact_path: str
 
@@ -204,7 +210,7 @@ async def video_analyze(file: UploadFile = File(...)):
     video_path_str = str(p)
 
     transcript = ""
-    scenes_data = []
+    scenes_data: List[Scene] = []
     summary = ""
 
     video_artifacts_dir = p.parent / p.stem
@@ -239,25 +245,24 @@ async def video_analyze(file: UploadFile = File(...)):
                 )
                 for (scene_num, _), img_path in image_filenames.items():
                     scene = scene_list[scene_num - 1]
-                    frame_info = {
-                        "t": scene[1].get_seconds(),
-                        "path": str(Path(img_path).relative_to(MM_DIR)),
-                        "ocr": "", "caption": ""
-                    }
+                    frame_info = Scene(
+                        t=scene[1].get_seconds(),
+                        path=str(Path(img_path).relative_to(MM_DIR)),
+                    )
                     if VIDEO_CONFIG.get("run_caption_on_keyframes", False) and blip_model:
                         raw_image = Image.open(img_path).convert("RGB")
                         inputs = blip_processor(raw_image, return_tensors="pt")
                         out = blip_model.generate(**inputs)
-                        frame_info["caption"] = blip_processor.decode(out[0], skip_special_tokens=True)
+                        frame_info.caption = blip_processor.decode(out[0], skip_special_tokens=True)
                     if VIDEO_CONFIG.get("run_ocr_on_keyframes", False) and ocr_reader:
                         result = ocr_reader.ocr(img_path, cls=True)
                         if result and result[0] is not None:
-                            frame_info["ocr"] = "\n".join([line[1][0] for line in result[0]])
+                            frame_info.ocr = "\n".join([line[1][0] for line in result[0]])
                     scenes_data.append(frame_info)
         except Exception:
             pass
 
-        summary = " ".join([f["caption"] for f in scenes_data if f["caption"]])
+        summary = " ".join([s.caption for s in scenes_data if s.caption])
 
     except Exception as e:
         summary = f"A fatal error occurred during video analysis: {e}"


### PR DESCRIPTION
## Summary
- define Scene pydantic model for video scenes and update VideoAnalysisResponse to use it
- instantiate Scene objects when analyzing video keyframes
- add unit tests validating Scene required fields

## Testing
- `pytest backend/tests/test_multimodal_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c759b56b8c8321a881f553ed250b3f