### PR TITLE
Use absolute imports for search modules

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -24,9 +24,9 @@ from tools.live_browse import (
     FetchResponseItem,
 )
 from tools.live_browse_utils import compute_reliability, pick_hubs
-from ..search.query_bundle import build_query_bundle, CONFIG as SEARCH_CFG
-from ..search.run_bundle import run_bundle
-from ..search.select_and_ingest import select_and_ingest
+from search.query_bundle import build_query_bundle, CONFIG as SEARCH_CFG
+from search.run_bundle import run_bundle
+from search.select_and_ingest import select_and_ingest
 from tools.multimodal import (
     image_analyze,
     audio_transcribe,

--- a/backend/search/select_and_ingest.py
+++ b/backend/search/select_and_ingest.py
@@ -8,10 +8,10 @@ from urllib.parse import urlparse
 import numpy as np
 from sentence_transformers import SentenceTransformer
 
-from ..tools.live_browse import fetch, ingest, FetchRequest, IngestRequest
-from ..tools.live_browse_utils import compute_reliability
-from .urlnorm import canonicalize
-from .query_bundle import CONFIG
+from tools.live_browse import fetch, ingest, FetchRequest, IngestRequest
+from tools.live_browse_utils import compute_reliability
+from search.urlnorm import canonicalize
+from search.query_bundle import CONFIG
 
 _model: SentenceTransformer | None = None
 
@@ -110,7 +110,7 @@ def select_and_ingest(user_query: str, hits: List[Dict]) -> List[Dict]:
 
 
 def fetch_config():
-    from ..tools.live_browse import get_config
+    from tools.live_browse import get_config
     cfg = get_config()
     return cfg.get("ingest_policy", {})
 

--- a/backend/tools/live_browse.py
+++ b/backend/tools/live_browse.py
@@ -10,11 +10,11 @@ from typing import List, Dict, Any, Optional
 from datetime import datetime
 import os
 import hashlib
-from .search_engine import SearchEngine
+from tools.search_engine import SearchEngine
 from pathlib import Path
 import logging
 from urllib.parse import urlparse
-from ..search.urlnorm import canonicalize
+from search.urlnorm import canonicalize
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- replace relative search imports with absolute backend-rooted modules
- update select_and_ingest to import live_browse and helpers without relative syntax
- ensure uvicorn entrypoint works from repo root

## Testing
- `python -m py_compile backend/tools/live_browse.py backend/api/chat.py backend/search/select_and_ingest.py`
- `uvicorn backend.app:app --help`
- `pytest` *(fails: requests.exceptions.ProxyError: MaxRetryError HTTPSConnectionPool)*

------
https://chatgpt.com/codex/tasks/task_e_68c771a840e0832193a81369f36617d5